### PR TITLE
test: stabilize randomBoolean tests via RNG injection and mocks

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -2,8 +2,13 @@ import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../ut
 
 describe('Intentionally Flaky Tests', () => {
   test('random boolean should be true', () => {
-    const result = randomBoolean();
+    const result = randomBoolean(() => 0.9);
     expect(result).toBe(true);
+  });
+
+  test('random boolean should be false', () => {
+    const result = randomBoolean(() => 0.1);
+    expect(result).toBe(false);
   });
 
   test('unstable counter should equal exactly 10', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-export function randomBoolean(): boolean {
-  return Math.random() > 0.5;
+export function randomBoolean(rng: () => number = Math.random): boolean {
+  return rng() > 0.5;
 }
 
 export function randomDelay(min: number = 100, max: number = 1000): Promise<void> {


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** The test 'Intentionally Flaky Tests random boolean should be true' asserted a random outcome to always be true, producing inherent nondeterminism (~50% pass rate).
- **Proposed fix:** Stub `Math.random` in tests to deterministic values (0.9 for true, 0.1 for false); refactor `randomBoolean` to accept an injectable RNG (`rng = Math.random`) and pass fixed RNGs in tests; apply RNG/time DI patterns and Jest controls (`jest.spyOn`, `jest.useFakeTimers`, `jest.setSystemTime`) to similar flaky cases.
- **Verification:** **Verification:** 1/1 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)