### PR TITLE
test: make flaky tests deterministic via RNG/timer control

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -2,8 +2,10 @@ import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../ut
 
 describe('Intentionally Flaky Tests', () => {
   test('random boolean should be true', () => {
+    const spy = jest.spyOn(Math, 'random').mockReturnValue(0.6);
     const result = randomBoolean();
     expect(result).toBe(true);
+    spy.mockRestore();
   });
 
   test('unstable counter should equal exactly 10', () => {


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** Tests assert random outcomes using `Math.random` and real timers; utils hardcode randomness, preventing control. "Intentionally Flaky Tests random boolean should be true" fails intermittently due to nondeterministic `randomBoolean()`.
- **Proposed fix:** Remove nondeterminism by mocking `Math.random` and timers, and/or injecting `rng`/`timer` into utils; assert deterministic invariants; add failure-path tests; optionally use `jest.retryTimes(2)` in CI until refactors land.
- **Verification:** **Verification:** Verification tests were executed, but the specific test still exhibits flakiness. The proposed changes may have addressed some issues but further investigation and fixes are needed.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)