### PR TITLE
test: deflake random/time-dependent tests via mocking and fake timers

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,50 +1,55 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
   test('random boolean should be true', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.9);
     const result = randomBoolean();
     expect(result).toBe(true);
   });
 
   test('unstable counter should equal exactly 10', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.0); // ensure no noise
     const result = unstableCounter();
     expect(result).toBe(10);
   });
 
   test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
-    expect(result).toBe('Success');
+    jest.useFakeTimers();
+    const randomSpy = jest.spyOn(Math, 'random');
+    randomSpy.mockReturnValueOnce(0.0); // shouldFail -> false
+    randomSpy.mockReturnValueOnce(0.0); // delay -> 0ms
+
+    const promise = flakyApiCall();
+
+    jest.runAllTimers();
+    await expect(promise).resolves.toBe('Success');
   });
 
   test('timing-based test with race condition', async () => {
-    const startTime = Date.now();
-    await randomDelay(50, 150);
-    const endTime = Date.now();
-    const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
-  });
+    jest.useFakeTimers();
+    jest.spyOn(Math, 'random').mockReturnValue(0.0); // choose min delay
 
-  test('multiple random conditions', () => {
-    const condition1 = Math.random() > 0.3;
-    const condition2 = Math.random() > 0.3;
-    const condition3 = Math.random() > 0.3;
-    
-    expect(condition1 && condition2 && condition3).toBe(true);
+    const done = jest.fn();
+    const p = randomDelay(50, 150).then(done);
+
+    jest.advanceTimersByTime(50);
+    await p;
+
+    expect(done).toHaveBeenCalled();
   });
 
   test('date-based flakiness', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.123Z'));
+
     const now = new Date();
     const milliseconds = now.getMilliseconds();
-    
-    expect(milliseconds % 7).not.toBe(0);
-  });
 
-  test('memory-based flakiness using object references', () => {
-    const obj1 = { value: Math.random() };
-    const obj2 = { value: Math.random() };
-    
-    const compareResult = obj1.value > obj2.value;
-    expect(compareResult).toBe(true);
+    expect(milliseconds % 7).not.toBe(0);
   });
 });


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** The test "Intentionally Flaky Tests random boolean should be true" asserts a random outcome to always be true while `randomBoolean()` depends on `Math.random() > 0.5`, producing ~50% false results; other tests rely on random noise, real timers, and nondeterministic async delays, making results inherently flaky.
- **Proposed fix:** Control nondeterminism by mocking `Math.random` via `jest.spyOn(Math, 'random')` with deterministic sequences (e.g., `mockReturnValueOnce(0.9)` / `mockReturnValueOnce(0.1)`); for `unstableCounter`, assert a safe range (e.g., [9, 11]) or drive the random to cover noise/no-noise paths; use `jest.useFakeTimers()` and `jest.setSystemTime()` for date/time; test delays with `jest.advanceTimersByTime` and assert completion rather than wall-clock thresholds; for `flakyApiCall`, mock randomness for both the fail flag and delay and use fake timers to deterministically cover resolve/reject; remove or rewrite non-value tests (multiple random conditions, memory-based flakiness) and add a small helper to run tests with predefined random sequences.
- **Verification:** **Verification:** 1/1 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)