### PR TITLE
test: deflake 'random boolean should be true' with mocked RNG

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,49 +1,62 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
 describe('Intentionally Flaky Tests', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
   test('random boolean should be true', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.9);
     const result = randomBoolean();
     expect(result).toBe(true);
   });
 
   test('unstable counter should equal exactly 10', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.0);
     const result = unstableCounter();
     expect(result).toBe(10);
   });
 
   test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
-    expect(result).toBe('Success');
+    jest.useFakeTimers();
+    const randomSpy = jest.spyOn(Math, 'random');
+    randomSpy.mockReturnValueOnce(0.0);
+    randomSpy.mockReturnValueOnce(0.0);
+    const resultPromise = flakyApiCall();
+    jest.runAllTimers();
+    await expect(resultPromise).resolves.toBe('Success');
   });
 
   test('timing-based test with race condition', async () => {
-    const startTime = Date.now();
-    await randomDelay(50, 150);
-    const endTime = Date.now();
-    const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
+    jest.useFakeTimers();
+    jest.spyOn(Math, 'random').mockReturnValue(0.0);
+    const delayPromise = randomDelay(50, 150);
+    jest.advanceTimersByTime(50);
+    await expect(delayPromise).resolves.toBeUndefined();
   });
 
   test('multiple random conditions', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.9);
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
-    
     expect(condition1 && condition2 && condition3).toBe(true);
   });
 
   test('date-based flakiness', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-01-01T00:00:00.123Z'));
     const now = new Date();
     const milliseconds = now.getMilliseconds();
-    
     expect(milliseconds % 7).not.toBe(0);
   });
 
   test('memory-based flakiness using object references', () => {
+    const rnd = jest.spyOn(Math, 'random');
+    rnd.mockReturnValueOnce(0.9);
+    rnd.mockReturnValueOnce(0.1);
     const obj1 = { value: Math.random() };
     const obj2 = { value: Math.random() };
-    
     const compareResult = obj1.value > obj2.value;
     expect(compareResult).toBe(true);
   });


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** Tests and utils used real Math.random, setTimeout, and Date.now, leading to nondeterministic outcomes; specifically, Intentionally Flaky Tests random boolean should be true depended on random chance.
- **Proposed fix:** Mock Math.random in tests (e.g., jest.spyOn(Math, 'random').mockReturnValue(0.9)), use Jest fake timers to control async timing deterministically, and set a fixed system time for date-based assertions; optionally inject RNG/timer dependencies into utils for full determinism.
- **Verification:** **Verification:** 1/1 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)