### PR TITLE
fix: resolve date-based flakiness in test suite

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -34,10 +34,15 @@ describe('Intentionally Flaky Tests', () => {
   });
 
   test('date-based flakiness', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-01-15T12:00:00.001Z')); // milliseconds = 1
+
     const now = new Date();
     const milliseconds = now.getMilliseconds();
-    
+
     expect(milliseconds % 7).not.toBe(0);
+
+    jest.useRealTimers();
   });
 
   test('memory-based flakiness using object references', () => {


### PR DESCRIPTION
**Chunk has come up with the following:**

- **Root cause:** The test "Intentionally Flaky Tests date-based flakiness" failed approximately 14.3% of the time when `new Date().getMilliseconds() % 7 === 0`. Since milliseconds range from 0-999, any value divisible by 7 (0, 7, 14, 21, ..., 994) caused the test to fail non-deterministically.

- **Proposed fix:** Mock the system time using Jest's fake timers (`jest.useFakeTimers()` and `jest.setSystemTime()`) to set a deterministic millisecond value that ensures the test always passes. This eliminates the dependency on the actual system clock and makes the test behavior predictable and repeatable.

- **Verification:** Unable to parse verification test results. Please review the proposed changes manually and verify the test behavior.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/7aab5ae6-2188-4044-b0e7-0e86338853c3)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)