### PR TITLE
fix: remove non-deterministic date logic from flaky test

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -34,10 +34,16 @@ describe('Intentionally Flaky Tests', () => {
   });
 
   test('date-based flakiness', () => {
+    // Mock Date to return a deterministic timestamp where milliseconds % 7 !== 0
+    const mockDate = new Date('2025-10-07T12:00:00.123Z'); // milliseconds = 123, 123 % 7 = 4
+    jest.spyOn(global, 'Date').mockImplementation(() => mockDate as any);
+
     const now = new Date();
     const milliseconds = now.getMilliseconds();
-    
+
     expect(milliseconds % 7).not.toBe(0);
+
+    jest.restoreAllMocks();
   });
 
   test('memory-based flakiness using object references', () => {


### PR DESCRIPTION
**Chunk has come up with the following:**

- **Root cause:** The test "Intentionally Flaky Tests date-based flakiness" fails intermittently (14.3% failure rate) because it uses `Date.now() % 7 !== 0`, which fails whenever milliseconds are divisible by 7 (values 0, 7, 14, ..., 994 out of 0-999 range).

- **Proposed fix:** Replace the non-deterministic date-based assertion with either a mocked Date object returning a fixed timestamp, or remove the probabilistic check entirely and use a deterministic assertion. This ensures the test produces consistent results across all executions.

- **Verification:** Unable to parse verification test results. Please review the proposed changes manually and verify the test behavior.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/7aab5ae6-2188-4044-b0e7-0e86338853c3)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)