### PR TITLE
fix(tests): deflake by injecting RNG/timers and freezing time

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -1,50 +1,96 @@
 import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../utils';
 
+function seqRng(...values: number[]): () => number {
+  let i = 0;
+  return () => values[i++] ?? values[values.length - 1] ?? 0;
+}
+
 describe('Intentionally Flaky Tests', () => {
   test('random boolean should be true', () => {
-    const result = randomBoolean();
+    const result = randomBoolean(() => 0.9);
     expect(result).toBe(true);
   });
 
-  test('unstable counter should equal exactly 10', () => {
-    const result = unstableCounter();
+  test('random boolean can be false', () => {
+    const result = randomBoolean(() => 0.1);
+    expect(result).toBe(false);
+  });
+
+  test('unstable counter equals 10 when no noise', () => {
+    const result = unstableCounter(() => 0.5);
     expect(result).toBe(10);
   });
 
+  test('unstable counter can be 9 (negative noise)', () => {
+    const result = unstableCounter(seqRng(0.9, 0.1));
+    expect(result).toBe(9);
+  });
+
+  test('unstable counter can be 11 (positive noise)', () => {
+    const result = unstableCounter(seqRng(0.9, 0.9));
+    expect(result).toBe(11);
+  });
+
   test('flaky API call should succeed', async () => {
-    const result = await flakyApiCall();
+    const result = await flakyApiCall({ shouldFail: false, delayMs: 0 });
     expect(result).toBe('Success');
   });
 
-  test('timing-based test with race condition', async () => {
-    const startTime = Date.now();
-    await randomDelay(50, 150);
-    const endTime = Date.now();
-    const duration = endTime - startTime;
-    
-    expect(duration).toBeLessThan(100);
+  test('flaky API call should fail', async () => {
+    await expect(flakyApiCall({ shouldFail: true, delayMs: 0 })).rejects.toThrow('Network timeout');
+  });
+
+  test('timing-based test using fake timers', async () => {
+    jest.useFakeTimers();
+    const done = jest.fn();
+    const p = randomDelay(60, 60);
+    p.then(done);
+
+    jest.advanceTimersByTime(60);
+
+    // Allow promise microtask to resolve
+    await Promise.resolve();
+    expect(done).toHaveBeenCalled();
+
+    jest.useRealTimers();
   });
 
   test('multiple random conditions', () => {
+    const spy = jest.spyOn(Math, 'random')
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9)
+      .mockReturnValueOnce(0.9);
+
     const condition1 = Math.random() > 0.3;
     const condition2 = Math.random() > 0.3;
     const condition3 = Math.random() > 0.3;
-    
+
     expect(condition1 && condition2 && condition3).toBe(true);
+    spy.mockRestore();
   });
 
-  test('date-based flakiness', () => {
+  test('date-based flakiness stabilized with fixed system time', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.001Z'));
+
     const now = new Date();
     const milliseconds = now.getMilliseconds();
-    
     expect(milliseconds % 7).not.toBe(0);
+
+    jest.useRealTimers();
   });
 
-  test('memory-based flakiness using object references', () => {
+  test('memory-based flakiness with controlled values', () => {
+    const spy = jest.spyOn(Math, 'random')
+      .mockReturnValueOnce(0.8)
+      .mockReturnValueOnce(0.1);
+
     const obj1 = { value: Math.random() };
     const obj2 = { value: Math.random() };
-    
+
     const compareResult = obj1.value > obj2.value;
     expect(compareResult).toBe(true);
+
+    spy.mockRestore();
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,29 @@
-export function randomBoolean(): boolean {
-  return Math.random() > 0.5;
+export function randomBoolean(rng: () => number = Math.random): boolean {
+  return rng() > 0.5;
 }
 
-export function randomDelay(min: number = 100, max: number = 1000): Promise<void> {
-  const delay = Math.floor(Math.random() * (max - min + 1)) + min;
-  return new Promise(resolve => setTimeout(resolve, delay));
+export function randomDelay(
+  min: number = 100,
+  max: number = 1000,
+  opts: { rng?: () => number; setTimeoutImpl?: typeof setTimeout } = {}
+): Promise<void> {
+  const { rng = Math.random, setTimeoutImpl = setTimeout } = opts;
+  const delay = Math.floor(rng() * (max - min + 1)) + min;
+  return new Promise(resolve => setTimeoutImpl(resolve, delay));
 }
 
-export function flakyApiCall(): Promise<string> {
+export function flakyApiCall(opts: {
+  shouldFail?: boolean;
+  delayMs?: number;
+  rng?: () => number;
+  setTimeoutImpl?: typeof setTimeout;
+} = {}): Promise<string> {
+  const { rng = Math.random, setTimeoutImpl = setTimeout } = opts;
+  const shouldFail = opts.shouldFail ?? (rng() > 0.7);
+  const delay = opts.delayMs ?? (rng() * 500);
+
   return new Promise((resolve, reject) => {
-    const shouldFail = Math.random() > 0.7;
-    const delay = Math.random() * 500;
-    
-    setTimeout(() => {
+    setTimeoutImpl(() => {
       if (shouldFail) {
         reject(new Error('Network timeout'));
       } else {
@@ -22,8 +33,8 @@ export function flakyApiCall(): Promise<string> {
   });
 }
 
-export function unstableCounter(): number {
+export function unstableCounter(rng: () => number = Math.random): number {
   const base = 10;
-  const noise = Math.random() > 0.8 ? Math.floor(Math.random() * 3) - 1 : 0;
+  const noise = rng() > 0.8 ? Math.floor(rng() * 3) - 1 : 0;
   return base + noise;
 }


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** The suite used nondeterministic Math.random, real timers, and Date; specifically, the test "Intentionally Flaky Tests random boolean should be true" expected randomBoolean() to always be true despite being ~50% true.
- **Proposed fix:** Decouple randomness/time via dependency injection in utils (rng, timers) and make tests deterministic via injected dependencies or Jest mocks/fake timers; rewrite assertions to cover both success and failure paths.
- **Verification:** **Verification:** Verification completed with result "pass". Please review the test output and proposed changes.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)