### PR TITLE
fix(tests): deflake randomBoolean by mocking Math.random

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -2,8 +2,23 @@ import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../ut
 
 describe('Intentionally Flaky Tests', () => {
   test('random boolean should be true', () => {
-    const result = randomBoolean();
-    expect(result).toBe(true);
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.9);
+    try {
+      const result = randomBoolean();
+      expect(result).toBe(true);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  test('random boolean should be false', () => {
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.1);
+    try {
+      const result = randomBoolean();
+      expect(result).toBe(false);
+    } finally {
+      randomSpy.mockRestore();
+    }
   });
 
   test('unstable counter should equal exactly 10', () => {


### PR DESCRIPTION
Intentionally Flaky Tests random boolean should be true

**Chunk has come up with the following:**
- **Root cause:** The test asserted a fixed outcome from nondeterministic Math.random.
- **Proposed fix:** Mock Math.random in the test to return deterministic values (e.g., 0.9 for true and 0.1 for false), and assert both branches.
- **Verification:** Verification completed with result "pass". Please review the test output and proposed changes.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)