### PR TITLE
test: deflake 'random boolean should be true' via RNG control

### DIFF
--- a/src/__tests__/flaky.test.ts
+++ b/src/__tests__/flaky.test.ts
@@ -2,8 +2,10 @@ import { randomBoolean, randomDelay, flakyApiCall, unstableCounter } from '../ut
 
 describe('Intentionally Flaky Tests', () => {
   test('random boolean should be true', () => {
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.9);
     const result = randomBoolean();
     expect(result).toBe(true);
+    randomSpy.mockRestore();
   });
 
   test('unstable counter should equal exactly 10', () => {


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** Tests relied on nondeterministic randomness and real timers; in particular, the test Intentionally Flaky Tests random boolean should be true asserted a 50/50 random result to always be true.
- **Proposed fix:** Control nondeterminism by mocking or injecting RNG (e.g., jest.spyOn(Math, 'random').mockReturnValue(0.9) or randomBoolean(rng)); use Jest fake timers and fixed system time; stabilize assertions (ranges/deterministic inputs) and test both success/failure paths.
- **Verification:** **Verification:** Verification completed with result "pass". Please review the test output and proposed changes.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/549bda3a-f683-42b1-a802-c967e9926fab)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)