### PR TITLE
feat: add string utility library (stringUtils.ts)

### DIFF
--- a/src/__tests__/stringUtils.test.ts
+++ b/src/__tests__/stringUtils.test.ts
@@ -1,0 +1,90 @@
+import {
+  truncate,
+  toTitleCase,
+  slugify,
+  countOccurrences,
+  reverseString,
+  isPalindrome,
+} from "../stringUtils";
+
+describe("stringUtils", () => {
+  describe("truncate", () => {
+    test("returns original string when within limit", () => {
+      expect(truncate("hello", 10)).toBe("hello");
+    });
+
+    test("truncates and adds ellipsis when over limit", () => {
+      expect(truncate("hello world", 8)).toBe("hello...");
+    });
+
+    test("handles exact length match", () => {
+      expect(truncate("hello", 5)).toBe("hello");
+    });
+  });
+
+  describe("toTitleCase", () => {
+    test("capitalizes first letter of each word", () => {
+      expect(toTitleCase("hello world")).toBe("Hello World");
+    });
+
+    test("handles already-capitalized input", () => {
+      expect(toTitleCase("THE QUICK BROWN FOX")).toBe("The Quick Brown Fox");
+    });
+  });
+
+  describe("slugify", () => {
+    test("converts spaces to hyphens", () => {
+      expect(slugify("hello world")).toBe("hello-world");
+    });
+
+    test("strips special characters", () => {
+      expect(slugify("Hello, World!")).toBe("hello-world");
+    });
+
+    test("collapses multiple hyphens", () => {
+      expect(slugify("hello   world")).toBe("hello-world");
+    });
+  });
+
+  describe("countOccurrences", () => {
+    test("counts substring occurrences", () => {
+      expect(countOccurrences("banana", "an")).toBe(2);
+    });
+
+    test("returns 0 for empty substring", () => {
+      expect(countOccurrences("hello", "")).toBe(0);
+    });
+
+    test("returns 0 when substring not found", () => {
+      expect(countOccurrences("hello", "xyz")).toBe(0);
+    });
+  });
+
+  describe("reverseString", () => {
+    test("reverses a string", () => {
+      expect(reverseString("hello")).toBe("olleh");
+    });
+
+    test("handles empty string", () => {
+      expect(reverseString("")).toBe("");
+    });
+  });
+
+  describe("isPalindrome", () => {
+    test("returns true for palindrome", () => {
+      expect(isPalindrome("racecar")).toBe(true);
+    });
+
+    test("returns false for non-palindrome", () => {
+      expect(isPalindrome("hello")).toBe(false);
+    });
+
+    test("is case-insensitive", () => {
+      expect(isPalindrome("Racecar")).toBe(true);
+    });
+
+    test("ignores spaces", () => {
+      expect(isPalindrome("a man a plan a canal panama")).toBe(true);
+    });
+  });
+});

--- a/src/stringUtils.ts
+++ b/src/stringUtils.ts
@@ -1,0 +1,60 @@
+/**
+ * Truncates a string to a given length, appending an ellipsis if truncated.
+ */
+export function truncate(str: string, maxLength: number): string {
+  if (str.length <= maxLength) return str;
+  return str.slice(0, maxLength - 3) + "...";
+}
+
+/**
+ * Converts a string to title case (first letter of each word capitalized).
+ */
+export function toTitleCase(str: string): string {
+  return str
+    .toLowerCase()
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/**
+ * Slugifies a string for use in URLs.
+ * Lowercases, strips non-alphanumeric chars, replaces spaces with hyphens.
+ */
+export function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+/**
+ * Counts the occurrences of a substring within a string.
+ */
+export function countOccurrences(str: string, substring: string): number {
+  if (substring.length === 0) return 0;
+  let count = 0;
+  let index = 0;
+  while ((index = str.indexOf(substring, index)) !== -1) {
+    count++;
+    index += substring.length;
+  }
+  return count;
+}
+
+/**
+ * Reverses a string.
+ */
+export function reverseString(str: string): string {
+  return str.split("").reverse().join("");
+}
+
+/**
+ * Checks if a string is a palindrome (case-insensitive, ignores spaces).
+ */
+export function isPalindrome(str: string): boolean {
+  const cleaned = str.toLowerCase().replace(/\s/g, "");
+  return cleaned === cleaned.split("").reverse().join("");
+}


### PR DESCRIPTION
## Summary

Adds `src/stringUtils.ts` with 6 string helper functions and full test coverage in `src/__tests__/stringUtils.test.ts`.

**Functions added:** `truncate`, `toTitleCase`, `slugify`, `countOccurrences`, `reverseString`, `isPalindrome`

## Scope

This is a self-contained new module with no dependencies on other in-flight changes. It can be reviewed and merged independently.

**Merge order:** 1 of 5 (any order works — all splits are independent)

## Checks

- Typecheck: ✅ pass
- Lint: ⚠️ pre-existing error in `src/utils.ts` (not introduced by this PR)
- Tests (stringUtils): ✅ 17/17 pass

🤖 Split from #189 using [Claude Code](https://claude.com/claude-code)