### PR TITLE
ci: add parallelism, coverage reporting, ESLint tooling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,56 +1,70 @@
 version: 2.1
 orbs:
   node: circleci/node@7
+
 jobs:
   build-node:
-    # Build node project
     executor: node/default
     steps:
       - checkout
       - node/install-packages:
           pkg-manager: npm
+          cache-path: ~/project/node_modules
+          override-ci-command: npm ci
       - run:
+          name: Typecheck
           command: npm run build
       - run:
-          name: Create the ~/artifacts directory if it doesn't exist
+          name: Create artifacts directory
           command: mkdir -p ~/artifacts
-      # Copy output to artifacts dir
       - run:
-          name: Copy artifacts
-          command: cp -R build dist public .output .next .docusaurus ~/artifacts 2>/dev/null || true
+          name: Copy build artifacts
+          command: cp -R dist ~/artifacts 2>/dev/null || true
       - store_artifacts:
           path: ~/artifacts
           destination: node-build
+
   test-node:
     executor: node/default
+    parallelism: 2
     steps:
       - checkout
       - node/install-packages:
           pkg-manager: npm
+          cache-path: ~/project/node_modules
+          override-ci-command: npm ci
       - run:
-          name: Run tests
+          name: Run tests with coverage
           command: |
             mkdir -p test-results
             TEST_FILES=$(circleci tests glob "src/**/*.{test,spec}.{js,ts}")
-            echo "$TEST_FILES" | circleci tests run --command="xargs npm run test:run -- --reporter=junit --outputFile=test-results/junit.xml" --verbose
+            echo "$TEST_FILES" | circleci tests run \
+              --command="xargs npm run test:run -- --coverage --coverageDirectory=coverage --reporter=junit --outputFile=test-results/junit.xml" \
+              --verbose \
+              --split-by=timings
       - store_test_results:
           path: test-results
-  lint-node:
+      - store_artifacts:
+          path: coverage
+          destination: coverage-report
+
+  lint:
     executor: node/default
     steps:
       - checkout
       - node/install-packages:
           pkg-manager: npm
+          cache-path: ~/project/node_modules
+          override-ci-command: npm ci
       - run:
-          name: Run lint
+          name: Lint
           command: npm run lint
+
 workflows:
-  build:
+  ci:
     jobs:
       - build-node
-  test:
-    jobs:
-      - test-node
-  lint:
-    jobs:
-      - lint-node
+      - lint
+      - test-node:
+          requires:
+            - build-node

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,19 @@
 module.exports = {
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],
-  rules: {
-    "@typescript-eslint/no-unused-vars": "error",
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+  ],
+  env: {
+    node: true,
+    es2020: true,
+    jest: true,
   },
+  rules: {
+    "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    "@typescript-eslint/explicit-function-return-type": "warn",
+    "no-console": "warn",
+  },
+  ignorePatterns: ["dist/", "node_modules/", "coverage/"],
 };

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:run": "jest",
+    "test:coverage": "jest --coverage",
     "build": "tsc",
     "clean": "rm -rf dist",
-    "lint": "eslint 'src/**/*.ts' --ignore-pattern 'src/__tests__/**'"
+    "lint": "eslint 'src/**/*.ts'",
+    "lint:fix": "eslint 'src/**/*.ts' --fix"
   },
   "keywords": [],
   "author": "",
@@ -17,9 +19,9 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^24.2.1",
-    "@typescript-eslint/eslint-plugin": "^7.18.0",
-    "@typescript-eslint/parser": "^7.18.0",
-    "eslint": "^8.57.1",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^9.0.0",
     "jest": "^30.0.5",
     "jest-junit": "^16.0.0",
     "ts-jest": "^29.4.1",


### PR DESCRIPTION
## Summary

- **`.circleci/config.yml`** — adds npm caching, 2x test parallelism, coverage artifact upload, and a dedicated `lint` job; unifies workflows into a single `ci` workflow
- **`.eslintrc.js`** — expands ESLint config with TypeScript plugin rules (`no-unused-vars`, `explicit-function-return-type`, `no-console`) and environment settings
- **`package.json`** — adds `test:coverage`, `lint:fix` scripts; upgrades ESLint to v9 and `@typescript-eslint/*` to v8

## Scope

CI, linting config, and tooling scripts are tightly coupled (the CI lint job calls `npm run lint` which requires the ESLint package and config). These two commits are grouped together.

**Merge order:** 4 of 5 (any order works — all splits are independent)

## Checks

- Typecheck: ✅ pass
- Lint: ❌ **Known issue** — `package.json` upgrades to ESLint v9 but `.eslintrc.js` uses the legacy v8 format. ESLint v9 requires `eslint.config.js`. This issue exists in the original PR #189 and should be fixed before merge (either downgrade eslint to `^8`, or migrate `.eslintrc.js` to `eslint.config.js`).

🤖 Split from #189 using [Claude Code](https://claude.com/claude-code)